### PR TITLE
Add Libdragon as submodule and change build instructions to inform the user how to build this project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libdragon"]
+	path = libdragon
+	url = https://github.com/DragonMinded/libdragon
+	branch = unstable

--- a/README.md
+++ b/README.md
@@ -47,30 +47,54 @@ the textures after copying them to a temporary directory.
 
 This will be done inside of WSL, so if you don't have that set up, you should do so now.
 
-Install all the dependencies
-```apt install imagemagick ffmpeg rename build-essential libpng-dev git```
+Install all the dependencies.
+
+```bash
+sudo apt install imagemagick ffmpeg rename build-essential libpng-dev git
+```
 
 Download the .deb file from the [Libdragon Releases](https://github.com/DragonMinded/libdragon/releases) and install it.
-```dpkg -i gcc-toolchain-mips64-x86_64.deb```
+
+```bash
+sudo dpkg -i gcc-toolchain-mips64-x86_64.deb
+```
 
 Clone the repository.
-```git clone --recursive https://github.com/RosieSapphire/FNaF64.git fnaf```
+
+```bash
+git clone --recursive https://github.com/RosieSapphire/FNaF64.git fnaf
+```
 
 Move into the Libdragon directory and build it.
-```cd fnaf/libdragon/ && ./build.sh```
+
+```bash
+cd fnaf/libdragon/ && ./build.sh
+```
 
 Move back into the main directory and copy the assets.
-```cd .. && mkdir tmp/```
-```cp -rvf /mnt/c/<CTFAK Directory>/Dumps/Five\ Nights\ at\ Freddys/* tmp/```
+
+```bash
+cd .. && mkdir tmp/
+```
+
+```bash
+cp -rvf /mnt/c/<CTFAK Directory>/Dumps/Five\ Nights\ at\ Freddys/* tmp/
+```
 
 Run the script to convert the assets.
-```./copy_assets.sh tmp/Images/ tmp/Sounds/```
+```bash
+./copy_assets.sh tmp/Images/ tmp/Sounds/
+```
 
 Remove the temporary directory.
-```rm -r tmp/```
+```bash
+rm -r tmp/
+```
 
 After this, you should be good to build the ROM.
-```make -j```
+```bash
+make -j
+```
 
 Now you can run it, or put it on an N64 Flashcart via
 SD card or with the [UNFLoader developed by Buu342](https://github.com/buu342/N64-UNFLoader).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I would like to give a special thanks to [Rasky](https://github.com/rasky) and
 journey, and I'm really happy with this so far.
 
 # YouTube Tutorial
-For those of you who are more visual learners, [https://youtu.be/cSOmlyvK9gQ](here is a tutorial)
+For those of you who are more visual learners, [here is a tutorial](https://youtu.be/cSOmlyvK9gQ)
 I made for how to do everything necessary to compile the ROM.
 
 # Prerequisites

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ have to be compressed, both in color depth and image size. With the help of
 a handy-dandy tool I wrote in bash, which utilizes ImageMagick, we can convert
 the textures after copying them to a temporary directory.
 
-This will be done inside of WSL, so if you don't have that set up, you should do so now.
+This will be done inside of [WSL](https://aka.ms/wsl), so if you don't have that set up, you should do so now.
 
 Install all the dependencies.
 
@@ -93,7 +93,7 @@ rm -r tmp/
 
 After this, you should be good to build the ROM.
 ```bash
-make -j
+make -j4
 ```
 
 Now you can run it, or put it on an N64 Flashcart via

--- a/README.md
+++ b/README.md
@@ -47,20 +47,30 @@ the textures after copying them to a temporary directory.
 
 This will be done inside of WSL, so if you don't have that set up, you should do so now.
 
-```
-git clone https://github.com/RosieSapphire/FNaF64.git fnaf
-cd fnaf/
-mkdir tmp
-cp -rvf /mnt/c/<CTFAK Directory>/Dumps/Five\ Nights\ at\ Freddys/* tmp/
-./copy_assets.sh tmp/Images/ tmp/Sounds/
-rm -rf tmp/
-```
+Install all the dependencies
+```apt install imagemagick ffmpeg rename build-essential libpng-dev git```
+
+Download the .deb file from the [Libdragon Releases](https://github.com/DragonMinded/libdragon/releases) and install it.
+```dpkg -i gcc-toolchain-mips64-x86_64.deb```
+
+Clone the repository.
+```git clone --recursive https://github.com/RosieSapphire/FNaF64.git fnaf```
+
+Move into the Libdragon directory and build it.
+```cd fnaf/libdragon/ && ./build.sh```
+
+Move back into the main directory and copy the assets.
+```cd .. && mkdir tmp/```
+```cp -rvf /mnt/c/<CTFAK Directory>/Dumps/Five\ Nights\ at\ Freddys/* tmp/```
+
+Run the script to convert the assets.
+```./copy_assets.sh tmp/Images/ tmp/Sounds/```
+
+Remove the temporary directory.
+```rm -r tmp/```
 
 After this, you should be good to build the ROM.
-
-```
-make -j4
-```
+```make -j```
 
 Now you can run it, or put it on an N64 Flashcart via
 SD card or with the [UNFLoader developed by Buu342](https://github.com/buu342/N64-UNFLoader).


### PR DESCRIPTION
This PR adds Libragon as a submodule so that it git pull's itself down with the project as soon as someone tries to do so. This makes it easier for the user to understand how to compile the project itself and I've changed the build instructions to reflect that.