### PR TITLE
Install n64 toolchain in Docker using pre-built deb package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,18 +19,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         texinfo \
         wget
 
-ENV N64_INST=/n64_toolchain
-RUN mkdir $N64_INST /libdragon \
-    && chown ubuntu:ubuntu $N64_INST /libdragon
-WORKDIR $N64_INST
-USER ubuntu:ubuntu
+ENV N64_INST=/opt/libdragon
 
-COPY --chown=ubuntu:ubuntu ./libdragon/tools/build-toolchain.sh ./
-RUN export BUILD_PATH=$N64_INST/tmp \
-    && mkdir $BUILD_PATH \
-    && cd $BUILD_PATH \
-    && $N64_INST/build-toolchain.sh \
-    && rm -rf $BUILD_PATH
+ADD https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-x86_64.deb \
+    /gcc-toolchain-mips64-x86_64.deb
+
+RUN apt install --assume-yes /gcc-toolchain-mips64-x86_64.deb \
+    && rm /gcc-toolchain-mips64-x86_64.deb \
+    && chown -R ubuntu:ubuntu $N64_INST
+
+RUN mkdir /libdragon && chown ubuntu:ubuntu /libdragon
+USER ubuntu:ubuntu
 
 WORKDIR /libdragon
 ARG LIBDRAGON_BUILD_DIR=/home/ubuntu/libdragon-build

--- a/Dockerfile-dump
+++ b/Dockerfile-dump
@@ -27,6 +27,7 @@ WORKDIR /home/ubuntu
 
 ENV WINEARCH=win64
 ENV WINEPREFIX=/home/ubuntu/.wine64
+ENV WINEDEBUG=-all
 
 ADD --chown=ubuntu:ubuntu \
     https://builds.dotnet.microsoft.com/dotnet/Runtime/6.0.36/dotnet-runtime-6.0.36-win-x64.exe \
@@ -39,6 +40,7 @@ ADD --chown=ubuntu:ubuntu \
 # Install .NET 6.0 and ASP.NET Core 6.0
 RUN xvfb-run -a sh -c "\
         wineboot --init \
+        && winetricks nocrashdialog \
         && winetricks -q dotnet6 \
         && wine dotnet-runtime-6.0.36-x64.exe /quiet /norestart \
         && wine aspnetcore-runtime-6.0.36-x64.exe /norestart /quiet \

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ with-docker:
 	docker build \
 		--file Dockerfile \
 		--progress plain \
+		--platform linux/amd64 \
 		--target out \
 		--output type=local,dest=. \
 		.

--- a/make-with-docker.sh
+++ b/make-with-docker.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ ! -f FiveNightsatFreddys.exe ]; then
+    echo "ERROR: FiveNightsatFreddys.exe nmust be in the project directory!"
+    exit 1
+fi
+
+if [ ! -d CTFAK2.0 ] || [ ! -d libdragon ]; then
+    git submodule update --init
+fi
+
+if [ "$(uname -m)" != "x86_64" ]; then
+    echo "WARNING: This project is only supported on x86_64 systems."
+    echo "         You may encounter issues building on other platforms!"
+fi
+
+if [ ! -d dump ]; then
+    # Build CTFAK.Cli
+    if [ ! -d CTFAK.Cli ]; then
+        docker build \
+            --file Dockerfile-ctfak \
+            --progress plain \
+            --platform linux/amd64 \
+            --target out \
+            --output type=local,dest=. \
+            .
+    fi
+
+    # Dump the game assets
+    docker build \
+        --file Dockerfile-dump \
+        --progress plain \
+        --platform linux/amd64 \
+        --target out \
+        --output type=local,dest=. \
+        .
+fi
+
+# Build the ROM
+docker build \
+    --file Dockerfile \
+    --progress plain \
+    --platform linux/amd64 \
+    --target out \
+    --output type=local,dest=. \
+    .


### PR DESCRIPTION
Unfortunately, this is only for amd64 at the moment: LibDragon does not ship the toolchain deb for arm64 (yet!)